### PR TITLE
Updated main.yml to use Microsoft action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Setup MSBuild.exe
-      uses: warrenbuckley/Setup-MSBuild@v1
+      uses: microsoft/Setup-MSBuild@v1
 
     - name: Build Project
       run: |


### PR DESCRIPTION
- Updated Setup-MSBuild action to use Microsoft as src.

Warrenbuckley [archived](https://github.com/warrenbuckley/Setup-MSBuild#status-archived) the Setup-MSBuild action as now Microsoft is maintaining it directly. It's probably better to use that directly.