### PR TITLE
Don't specify strict dotnet version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v2
       
     - name: Setup Dotnet
-      uses: actions/setup-dotnet@v1.5.0
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
       


### PR DESCRIPTION
Will hopefully resolve issues that came about in the recent Github Actions update w.r.t setting environmental vars.

[Example Error](https://github.com/simplyWiri/Dubs-Performance-Analyzer/runs/1427996952?check_suite_focus=true#step:3:24
)